### PR TITLE
Quote variables to filenames with spaces will work fine

### DIFF
--- a/svgToDxf.sh
+++ b/svgToDxf.sh
@@ -1,6 +1,7 @@
 #! /bin/bash
 #
 # Copyright (c) 2014 Will Winder
+# Modified by Andrey Orst 11.13.2018
 
 # Purpose:
 # This script simply runs a command with Inkscape to convert a file from svg to
@@ -12,7 +13,7 @@
 # added to your PATH. On most linux distributions you should be able to use apt
 # or similar to install the packages, on MacOSX you may need to use something
 # like ports to install pstoedit then manually add the PATH.
- 
+
 # License:
 # The MIT License (MIT)
 #
@@ -22,10 +23,10 @@
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -40,10 +41,10 @@ function svgToEps()
     echo "You need to pass in a filename." ; return
   fi
 
-  epsfile=${1%.*}.eps
+  epsfile="${1%.*}.eps"
 
-  echo "inkscape -f $1 -E $epsfile"
-  inkscape -f $1 -E $epsfile &> /dev/null
+  echo "inkscape -f '$1' -E '$epsfile'"
+  inkscape -f "$1" -E "$epsfile" >/dev/null 2>&1
 }
 
 function svgToDxf()
@@ -52,15 +53,15 @@ function svgToDxf()
     echo "You need to pass in a filename." ; return
   fi
 
-  base=${1%.*}
-  epsfile=${base}.eps
-  dxffile=${base}.dxf
+  base="${1%.*}"
+  epsfile="${base}.eps"
+  dxffile="${base}.dxf"
 
-  svgToEps $1
-  echo "pstoedit -dt -f 'dxf:-polyaslines -mm' ${epsfile} ${dxffile}"
-  pstoedit -dt -f 'dxf:-polyaslines -mm' ${epsfile} ${dxffile} &> /dev/null
-  rm $epsfile
+  svgToEps "$1"
+  echo "pstoedit -dt -f 'dxf:-polyaslines -mm' '${epsfile}' '${dxffile}'"
+  pstoedit -dt -f 'dxf:-polyaslines -mm' "${epsfile}" "${dxffile}" >/dev/null 2>&1
+  rm "$epsfile"
 }
 
 # Run the function
-svgToDxf $1
+svgToDxf "$1"


### PR DESCRIPTION
Hi, thanks for awesome script. I've had a problem with it since it couldn't work with names of files which contain spaces, and other special symbols. So I've fixed this. I've also replaced `&>` with `>/dev/null 2>&1` since it may not work in other shells.